### PR TITLE
Added update media functionality

### DIFF
--- a/api/mediaData.js
+++ b/api/mediaData.js
@@ -14,6 +14,18 @@ const getMedia = (uid) => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
+const getSingleMedia = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/media/${firebaseKey}.json`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
 const deleteMedia = (firebaseKey) => new Promise((resolve, reject) => {
   fetch(`${endpoint}/media/${firebaseKey}.json`, {
     method: 'DELETE',
@@ -22,7 +34,7 @@ const deleteMedia = (firebaseKey) => new Promise((resolve, reject) => {
     },
   })
     .then((response) => response.json())
-    .then((data) => resolve((data)))
+    .then((data) => resolve(data))
     .catch(reject);
 });
 
@@ -53,5 +65,5 @@ const updateMedia = (payload) => new Promise((resolve, reject) => {
 });
 
 export {
-  getMedia, deleteMedia, createMedia, updateMedia,
+  getMedia, getSingleMedia, deleteMedia, createMedia, updateMedia,
 };

--- a/components/forms/MediaForm.js
+++ b/components/forms/MediaForm.js
@@ -46,7 +46,7 @@ export default function MediaForm({ obj }) {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (obj.firebaseKey) {
-      updateMedia(formInput).then(() => router.push(`/media/${obj.firebaseKey}`));
+      updateMedia(formInput).then(() => router.push('/'));
     } else {
       const payload = { ...formInput, uid: user.uid };
       createMedia(payload).then(({ name }) => {

--- a/pages/media/edit/[firebaseKey].js
+++ b/pages/media/edit/[firebaseKey].js
@@ -1,0 +1,16 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import MediaForm from '../../../components/forms/MediaForm';
+import { getSingleMedia } from '../../../api/mediaData';
+
+export default function EditMedia() {
+  const [editItem, setEditItem] = useState({});
+  const router = useRouter();
+  const { firebaseKey } = router.query;
+
+  useEffect(() => {
+    getSingleMedia(firebaseKey).then(setEditItem);
+  }, [firebaseKey]);
+
+  return (<MediaForm obj={editItem} />);
+}


### PR DESCRIPTION
## Description
- Added updateMedia API call
- Added getSingleMedia API call
- Added dynamically routed page to edit media

## Related Issues
- #17 
- #18 

## Motivation and Context
This change is required because the user needs to be able to update media on their watchlist.

## How Can This Be Tested?
Click the edit button on a media card, input new info in the form, and submit.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
