### PR TITLE
Added view media details page

### DIFF
--- a/api/mergedData.js
+++ b/api/mergedData.js
@@ -1,0 +1,24 @@
+import { getSingleGenre } from './genreData';
+import { getSingleMedia } from './mediaData';
+import { getSingleNetwork } from './networkData';
+import { getSingleType } from './typeData';
+
+const viewMediaDetails = (firebaseKey) => new Promise((resolve, reject) => {
+  getSingleMedia(firebaseKey)
+    .then((mediaObj) => {
+      const genrePromise = getSingleGenre(mediaObj.genre_id);
+      const networkPromise = getSingleNetwork(mediaObj.network_id);
+      const typePromise = getSingleType(mediaObj.type_id);
+
+      Promise.all([genrePromise, networkPromise, typePromise])
+        .then(([genreObj, networkObj, typeObj]) => {
+          resolve({
+            genreObj, networkObj, typeObj, ...mediaObj,
+          });
+        })
+        .catch((error) => reject(error));
+    })
+    .catch((error) => reject(error));
+});
+
+export default viewMediaDetails;

--- a/pages/media/[firebaseKey].js
+++ b/pages/media/[firebaseKey].js
@@ -1,0 +1,35 @@
+/* eslint-disable @next/next/no-img-element */
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { Col, Container, Row } from 'react-bootstrap';
+import viewMediaDetails from '../../api/mergedData';
+
+export default function ViewBook() {
+  const [mediaDetails, setMediaDetails] = useState({});
+  const router = useRouter();
+  const { firebaseKey } = router.query;
+
+  useEffect(() => {
+    viewMediaDetails(firebaseKey).then(setMediaDetails);
+  }, [firebaseKey]);
+
+  return (
+    <Container>
+      <Row>
+        <Col sm={4}>
+          <img src={mediaDetails.image_url} alt={mediaDetails.name} style={{ width: '300px' }} />
+        </Col>
+        <Col sm={8} className="text-white">
+          <h1>{mediaDetails.name}</h1>
+          <h6>
+            {mediaDetails.typeObj?.name}---
+            {mediaDetails.genreObj?.name}---
+            {mediaDetails.networkObj?.name}---
+            {mediaDetails.watched ? '✅' : ''}
+          </h6>
+          <p>{mediaDetails.overview || ''}</p>
+        </Col>
+      </Row>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Description
- Added merged data API call
- Added dynamic page to view media details

## Related Issues
- #19
- #20  

## Motivation and Context
This change is required because the user needs to be able to view media details.

## How Can This Be Tested?
Click the view button on a media card.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
